### PR TITLE
Hotfix: modify timetable filter condition

### DIFF
--- a/app/cars/serializers.py
+++ b/app/cars/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
 from cars.models import Car, CarTimeTable
-from core.utils import KST, time_format, UTC, get_only_date_from_datetime, get_only_date_end_from_datetime
+from core.utils import KST, time_format, get_only_date_from_datetime, get_only_date_end_from_datetime
 from prices.serializers import CarPriceDetailSerializer
 
 
@@ -50,8 +50,8 @@ class FilteredTimeTableListSerializer(serializers.ListSerializer):
     def to_representation(self, data):
         # trans str KST to datetime aware UTC format start-00:00:00 ~ end-23:59:59
         date_start = get_only_date_from_datetime(time_format(self.context.get('request').query_params.get('date_time_start')))
-        date_end = get_only_date_end_from_datetime(time_format(self.context.get('request').query_params.get('date_time_end')))
-        data = data.filter(date_time_start__gte=date_start, date_time_end__lte=date_end)
+        # date_end = get_only_date_end_from_datetime(time_format(self.context.get('request').query_params.get('date_time_end')))
+        data = data.filter(date_time_start__gte=date_start)
         return super(FilteredTimeTableListSerializer, self).to_representation(data)
 
 

--- a/app/cars/tests.py
+++ b/app/cars/tests.py
@@ -44,11 +44,11 @@ class CarTestCase(APITestCase):
 
         # 테스트용 차량 스케쥴 2개
         self.schedule_1 = CarTimeTable.objects.create(car_id=self.cars[0].id, zone_id=self.zones[0].id,
-                                                      date_time_start='2020-09-26T12:00:00+00:00',
-                                                      date_time_end='2020-09-26T12:30:00+00:00')
+                                                      date_time_start='2020-09-26T16:00:00+00:00',
+                                                      date_time_end='2020-09-26T18:30:00+00:00')
         self.schedule_2 = CarTimeTable.objects.create(car_id=self.cars[0].id, zone_id=self.zones[0].id,
-                                                      date_time_start='2020-09-27T13:00:00+00:00',
-                                                      date_time_end='2020-09-27T14:00:00+00:00')
+                                                      date_time_start='2020-09-27T16:00:00+00:00',
+                                                      date_time_end='2020-09-27T19:00:00+00:00')
         self.schedules = [self.schedule_1, self.schedule_2]
 
         # 테스트용 차량 보험료 2개
@@ -162,12 +162,12 @@ class CarTestCase(APITestCase):
             self.assertEqual(special, response_entry['insurance_prices']['special'])
 
         # 날짜 조건에 맞는 time_table만 나오는지 검사
-        for response_entry in response.data['time_tables']:
-            self.assertEqual(self.schedule_1.id, response_entry['id'])
-            self.assertEqual(self.schedule_1.zone_id, response_entry['zone'])
-            self.assertEqual(self.schedule_1.car_id, response_entry['car'])
-            self.assertEqual(self.schedule_1.date_time_start, trans_kst_to_utc(response_entry['date_time_start']))
-            self.assertEqual(self.schedule_1.date_time_end, trans_kst_to_utc(response_entry['date_time_end']))
+        for entry, response_entry in zip(self.schedules, response.data['time_tables']):
+            self.assertEqual(entry.id, response_entry['id'])
+            self.assertEqual(entry.zone_id, response_entry['zone'])
+            self.assertEqual(entry.car_id, response_entry['car'])
+            self.assertEqual(entry.date_time_start, trans_kst_to_utc(response_entry['date_time_start']))
+            self.assertEqual(entry.date_time_end, trans_kst_to_utc(response_entry['date_time_end']))
 
     # def test_should_create_multi_photos(self):
     #     """

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -5,7 +5,6 @@ import pytz
 from core.exceptions import NotValidInsuranceException, NotValidTimeFormatException, NotInTenMinutesException
 
 KST = pytz.timezone('Asia/Seoul')
-UTC = pytz.timezone('UTC')
 
 
 # 주행거리에 따른 반납 결제 요금
@@ -54,12 +53,12 @@ def trans_kst_to_utc(iso_datetime_str):
     return datetime.datetime.isoformat(utc_datetime)
 
 
-# date_time_start YYYY-MM-DDT00:00:00
+# date_time_start YYYY-MM-DDT15:00:00 (UTC) == YYYY-MM-DDT00:00:00 (KST)
 def get_only_date_from_datetime(datetime_format):
-    only_date = datetime_format.replace(hour=0, minute=0, second=0)
+    only_date = datetime_format.replace(hour=15, minute=0, second=0)
     return only_date
 
-# date_time_end YYYY-MM-DDT23:59:59
+# date_time_end YYYY-MM-DDT14:59:59 (UTC) == YYYY-MM-DDT23:59:59 (KST)
 def get_only_date_end_from_datetime(datetime_format):
-    only_date = datetime_format.replace(hour=23, minute=59, second=59)
+    only_date = datetime_format.replace(hour=14, minute=59, second=59)
     return only_date


### PR DESCRIPTION
차량의 타임 테이블 필터 조건 수정
예약 종료 날짜에 따라 어디까지 필터를 줘야 할지 달라지기 때문에,
일단 사용자가 원하는 시작날짜가 속하는 타임테이블부터 모두 반환하게 변경